### PR TITLE
Use 'alt' for block select on Mac instead of 'control' because OSX captures control-click

### DIFF
--- a/terminator/src/terminator/view/highlight/SelectionHighlighter.java
+++ b/terminator/src/terminator/view/highlight/SelectionHighlighter.java
@@ -116,7 +116,11 @@ public class SelectionHighlighter implements ClipboardOwner, MouseListener, Mous
     }
     
     private void updateSelectionMode(MouseEvent event) {
-        blockMode = event.isControlDown();
+
+        if(GuiUtilities.isMacOs()) 
+            blockMode = event.isAltDown();
+        else 
+            blockMode = event.isControlDown();
     }
     
     private DragHandler getDragHandlerForClick(MouseEvent e) {


### PR DESCRIPTION
I found that on Mac I can't use the block select feature because OSX captures the control-click interaction to present the context menu, and Terminator does not see the events at all. As a simple alternative, this change just enables the Alt key for block selection on mac instead of the Control key.