### PR TITLE
feature: support for setting local clipboard from remote terminal com…

### DIFF
--- a/terminator/src/terminator/TerminatorPreferences.java
+++ b/terminator/src/terminator/TerminatorPreferences.java
@@ -48,6 +48,16 @@ public class TerminatorPreferences extends Preferences {
      * Users may wish to disable this functionality for security reasons (eg company laptops).
      */
     public static final String LOG_TERMINAL_ACTIVITY = "logTerminalActivity";
+
+    /**
+     * Whether or not to allow shell commands to alter the system clipboard via OSC control codes
+     *
+     * See https://jdhao.github.io/2021/01/05/nvim_copy_from_remote_via_osc52/
+     *
+     * This is set to disabled by default because some people perceive it to be a security threat,
+     * so it is best not to surprise them with this enabled.
+     */
+    public static final String ENABLE_TERMINAL_CLIPBOARD_ACCESS = "enableTerminalClipboardAccess";
     
     private static final Color CREAM = new Color(0xfefaea);
     private static final Color LIGHT_BLUE = new Color(0xb3d4ff);
@@ -80,6 +90,7 @@ public class TerminatorPreferences extends Preferences {
         addPreference("Behavior", VISUAL_BELL, Boolean.TRUE, "Visual bell (as opposed to no bell)");
         addPreference("Behavior", USE_ALT_AS_META, Boolean.FALSE, "Use alt key as meta key (for Emacs)");
         addPreference("Behavior", LOG_TERMINAL_ACTIVITY, Boolean.TRUE, "Log terminal activity in $HOME/.terminator/logs/");
+        addPreference("Behavior", ENABLE_TERMINAL_CLIPBOARD_ACCESS, Boolean.FALSE, "Enable clipboard access from terminal commands");
         addPreference("Behavior", ERROR_LINK_CMD, "", "Error link handling script");
         
         addPreference("Appearance", ANTI_ALIAS, Boolean.TRUE, "Anti-alias text");

--- a/terminator/src/terminator/terminal/escape/XTermEscapeAction.java
+++ b/terminator/src/terminator/terminal/escape/XTermEscapeAction.java
@@ -2,6 +2,10 @@ package terminator.terminal.escape;
 
 import e.util.*;
 import java.awt.Color;
+import java.awt.Toolkit;
+import java.awt.datatransfer.StringSelection;
+import java.util.Base64;
+
 import terminator.*;
 import terminator.model.*;
 import terminator.terminal.*;
@@ -65,6 +69,16 @@ public class XTermEscapeAction implements TerminalAction {
                         return;
                     }
                     break;
+                case 52:
+					if(!Terminator.getPreferences().getBoolean(TerminatorPreferences.ENABLE_TERMINAL_CLIPBOARD_ACCESS))
+						return;
+                	int lastSemiColon = sequence.lastIndexOf(';');
+                	if(lastSemiColon>sequence.length()-1)
+                		return;
+                	String base64 = sequence.substring(lastSemiColon+1, sequence.length()-1);
+                	String contents = new String(Base64.getDecoder().decode(base64.getBytes()));
+                	Toolkit.getDefaultToolkit().getSystemClipboard().setContents(new StringSelection(contents), null);
+                	break;
             }
         }
         Log.warn("Unsupported XTerm escape sequence \"" + StringUtilities.escapeForJava(sequence) + "\".");


### PR DESCRIPTION
This pull request adds support for the OSC52 terminal command which allows a remote program to 
set the contents of the local system clipboard. 

See:

https://jdhao.github.io/2021/01/05/nvim_copy_from_remote_via_osc52/

This can be really useful when you are working in a hybrid 
mode with a lot of transfer between a remote system and the local one.

This functionality is disabled by default, and a new option is added in preferences to enable it.